### PR TITLE
Fix for missing index.json

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -361,6 +361,7 @@ directory.  For example, if there was no package.json file in the above
 example, then `require('./some-library')` would attempt to load:
 
 * `./some-library/index.js`
+* `./some-library/index.json`
 * `./some-library/index.node`
 
 ## Loading from `node_modules` Folders


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added
##### Affected core subsystem(s)
- doc
##### Description of change

Fix a missing point about the index.json file is loaded, in "Folders as modules"
